### PR TITLE
Fix pytest configuration for package imports

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,2 @@
+"""Core package for the 730 Radio Bot."""
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 asyncio_mode = auto
+pythonpath = .


### PR DESCRIPTION
## Summary
- add a package initializer so the `bot` module can be imported during tests
- configure pytest to include the repository root on `PYTHONPATH` for reliable package discovery

## Testing
- `pytest` *(fails: requires pytest-asyncio plugin for async tests)*

------
https://chatgpt.com/codex/tasks/task_e_68dde15cf868832cbbff8a4e53ef14a3