### PR TITLE
Install zlib runtime dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends tzdata git && \
+    apt-get install -y --no-install-recommends tzdata git zlib1g && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- add zlib1g to the Docker image to provide libz.so.1 for Python C extensions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e326c6ff48832c80062826366a0939