### PR TITLE
Improve boolean env parsing for message scanning toggle

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -88,12 +88,29 @@ def _int_from_env(name: str) -> int | None:
         return None
 
 
+def _bool_from_env(name: str, *, default: bool) -> bool:
+    """Return a boolean parsed from the environment, accepting common truthy strings."""
+
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+
+    logging.warning("Environment variable %s=%r is not a recognized boolean", name, raw)
+    return default
+
+
 TOKEN = os.getenv("DISCORD_TOKEN")
 CHANNEL_ID = _int_from_env("CHANNEL_ID")
 GUILD_ID = _int_from_env("GUILD_ID")
 PLAYLIST = os.getenv("PLAYLIST_ID")
 KEYWORD = "730radio"
-ENABLE_MESSAGE_SCANNING = os.getenv("ENABLE_MESSAGE_SCANNING", "1") == "1"
+ENABLE_MESSAGE_SCANNING = _bool_from_env("ENABLE_MESSAGE_SCANNING", default=True)
 
 logging.basicConfig(level=logging.INFO)
 intents = discord.Intents.default()

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -1,0 +1,26 @@
+def test_bool_from_env_truthy(monkeypatch):
+    import bot.main as main
+
+    monkeypatch.setenv("ENABLE_MESSAGE_SCANNING", "true")
+
+    assert main._bool_from_env("ENABLE_MESSAGE_SCANNING", default=False) is True
+
+
+def test_bool_from_env_falsey(monkeypatch):
+    import bot.main as main
+
+    monkeypatch.setenv("ENABLE_MESSAGE_SCANNING", "OFF")
+
+    assert main._bool_from_env("ENABLE_MESSAGE_SCANNING", default=True) is False
+
+
+def test_bool_from_env_invalid_logs_warning(monkeypatch, caplog):
+    import bot.main as main
+
+    monkeypatch.setenv("ENABLE_MESSAGE_SCANNING", "maybe")
+
+    with caplog.at_level("WARNING"):
+        result = main._bool_from_env("ENABLE_MESSAGE_SCANNING", default=True)
+
+    assert result is True
+    assert any("not a recognized boolean" in message for message in caplog.messages)


### PR DESCRIPTION
## Summary
- add a reusable helper to parse boolean environment variables with clear warnings
- use the helper for ENABLE_MESSAGE_SCANNING to honor common truthy/falsey strings
- cover the new helper with unit tests for truthy, falsey, and invalid values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fcede41c5c832cad3440e35eccf80b