### PR TITLE
Ensure slash command clears thinking state

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -390,7 +390,12 @@ if tree is not None:
                 fallback_sender=interaction.followup.send,
             )
 
-            # Intentionally no ephemeral success message to avoid redundancy
+            # Always clear the deferred "thinking" state with an ephemeral ack
+            await _safe_followup_send(
+                interaction,
+                "Video added to the playlist. ✅",
+                ephemeral=True,
+            )
         except CredentialsExpiredError as e:
             await _safe_followup_send(interaction, str(e), ephemeral=True)
         except Exception as e:


### PR DESCRIPTION
## Summary
- send an ephemeral follow-up after a successful /addradio run so the deferred state completes

## Testing
- pytest *(fails: async fixtures require pytest-asyncio plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68fcf0aa0be4832cbc72f784e53083fa