### PR TITLE
Include playlist link in success announcements

### DIFF
--- a/tests/test_discord_on_message.py
+++ b/tests/test_discord_on_message.py
@@ -73,6 +73,11 @@ async def test_on_message_adds_two_videos(monkeypatch):
     assert added == [("AAAAAAA1111", "pl123"), ("BBBBBBB2222", "pl123")]
     # Two success reactions
     assert msg.reactions.count("✅") == 2
+    # Public messages should include the playlist link for visibility
+    playlist_link = "https://youtube.com/playlist?list=pl123"
+    contents = [entry["content"] for entry in msg.channel.sent_messages]
+    assert len(contents) == 2
+    assert all(playlist_link in content for content in contents)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a helper to resolve the shareable playlist URL from configuration
- include the playlist link in channel announcements when new videos are added
- extend the message flow test to assert the playlist URL is shown

## Testing
- pytest *(fails: async def functions are not natively supported without pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68fe9059d3c4832c85aaa8c17ff3c9a9