### PR TITLE
Clarify playlist success announcement

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -516,7 +516,7 @@ if tree is not None:
                 or getattr(user, "name", None)
                 or "someone"
             )
-            content_prefix = f"Added by {user_mention}"
+            content_prefix = f"Song added by {user_mention}"
             channel = await _resolve_channel_for_interaction(interaction)
             await _announce_added(
                 meta=meta,


### PR DESCRIPTION
## Summary
- update the success announcement prefix to say "Song added by" for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68feac7ed074832c9d1788665a39230b