### PR TITLE
Document production rebuild procedure in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,11 @@ Set via `.env`:
 2. On RPIZelda:
    - `cd ~/docker/T-730/T-730-Prod`
    - `git pull origin main`
-   - `docker compose up -d --build`
+   - Stop the existing stack to ensure the old container is gone:
+     - `docker compose down`
+   - Rebuild and recreate the production bot with a fresh image:
+     - `docker compose build --no-cache radiobot`
+     - `docker compose up -d --force-recreate radiobot`
+   - Confirm the new build is running (optional):
+     - `docker compose ps`
+     - `docker compose logs -f radiobot`


### PR DESCRIPTION
## Summary
- expand the production deployment steps with the full rebuild process for the radiobot stack

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ff82dd8c60832ca51c927be5e5c60f