### PR TITLE
Support multi-video slash command input

### DIFF
--- a/bot/youtube/urls.py
+++ b/bot/youtube/urls.py
@@ -57,11 +57,18 @@ def canonical_video_ids_from_text(text: str) -> List[str]:
     scheme-less inputs like ``youtube.com/watch?v=...`` as well.
     """
 
+    # Treat commas as delimiters between potential URLs to support comma-separated lists.
+    normalized_text = re.sub(r",[\s]*", " ", text)
+
     # Find explicit http(s) URLs first
-    candidates = list(re.findall(r"https?://[^\s<>]+", text))
+    candidates = list(re.findall(r"https?://[^\s<>]+", normalized_text))
 
     # Also accept bare youtube links without scheme (e.g., youtube.com/... or youtu.be/...)
-    bare_matches = re.findall(r"(?:(?:www\.)?(?:youtube\.com|youtu\.be)/[^\s<>]+)", text, flags=re.IGNORECASE)
+    bare_matches = re.findall(
+        r"(?:(?:www\.)?(?:youtube\.com|youtu\.be)/[^\s<>]+)",
+        normalized_text,
+        flags=re.IGNORECASE,
+    )
     candidates.extend(bare_matches)
 
     seen = set()

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -23,3 +23,18 @@ def test_extracts_from_multiple_variants_and_deduplicates():
         "FFFFFFF6666",
     ]
 
+
+def test_extracts_from_comma_delimited_list():
+    text = (
+        "https://youtu.be/GAAAAAA1111,"
+        "https://youtu.be/HBBBBBB2222, "
+        "www.youtube.com/watch?v=ICCCCCC3333"
+    )
+
+    ids = canonical_video_ids_from_text(text)
+    assert ids == [
+        "GAAAAAA1111",
+        "HBBBBBB2222",
+        "ICCCCCC3333",
+    ]
+


### PR DESCRIPTION
## Summary
- allow the `/addradio` slash command to process multiple YouTube URLs from one invocation
- announce each successfully added video while reporting duplicates, long videos, and failures in the ephemeral reply
- treat commas as URL delimiters when parsing YouTube links and cover the behavior with a new test

## Testing
- pytest *(fails: async tests require a pytest asyncio plugin in this environment)*
- pytest tests/test_url_parsing.py -k comma


------
https://chatgpt.com/codex/tasks/task_e_69001a0bb5a0832c878225f5dd75f01d