### PR TITLE
Add packaging dependency for radiobot runtime

### DIFF
--- a/bot/requirements.txt
+++ b/bot/requirements.txt
@@ -3,3 +3,4 @@ google-api-python-client
 google-auth-oauthlib
 google-auth-httplib2
 python-dotenv
+packaging


### PR DESCRIPTION
## Summary
- add the packaging library to the radiobot runtime requirements

## Testing
- not run (Docker is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_6900dfc85fb4832ca8ca2646599148b0