### PR TITLE
Refactor bot configuration and retry helpers

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -1,0 +1,114 @@
+"""Configuration helpers for the T-730 bot."""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+from dotenv import load_dotenv
+
+_DEFAULT_COOLDOWN_SECONDS = 30
+_DEFAULT_MAX_VIDEO_DURATION_SECONDS = 10 * 60
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSY = {"0", "false", "no", "off"}
+
+
+def _int_from_env(name: str) -> int | None:
+    """Return an integer parsed from the environment or ``None`` when absent."""
+
+    raw = os.getenv(name)
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logging.warning("Environment variable %s=%r is not a valid integer", name, raw)
+        return None
+
+
+def _bool_from_env(name: str, *, default: bool) -> bool:
+    """Return a boolean parsed from the environment with forgiving semantics."""
+
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+
+    normalized = raw.strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSY:
+        return False
+
+    logging.warning("Environment variable %s=%r is not a recognized boolean", name, raw)
+    return default
+
+
+@dataclass(frozen=True)
+class BotConfig:
+    """Immutable configuration values loaded from environment variables."""
+
+    token: str | None
+    channel_id: int | None
+    guild_id: int | None
+    playlist_id: str | None
+    playlist_url: str | None
+    max_video_duration_seconds: int
+    cooldown_seconds: int
+    health_host: str
+    health_port: int
+
+    @property
+    def resolved_playlist_url(self) -> str | None:
+        """Return a shareable playlist URL when available."""
+
+        if self.playlist_url:
+            return self.playlist_url
+        if self.playlist_id:
+            return f"https://youtube.com/playlist?list={self.playlist_id}"
+        return None
+
+
+def load_config() -> BotConfig:
+    """Load configuration from the environment and provide sane defaults."""
+
+    load_dotenv()
+
+    token = os.getenv("DISCORD_TOKEN")
+    channel_id = _int_from_env("CHANNEL_ID")
+    guild_id = _int_from_env("GUILD_ID")
+    playlist_id = os.getenv("PLAYLIST_ID")
+    playlist_url = os.getenv("PLAYLIST_URL")
+
+    max_video_duration = _int_from_env("MAX_VIDEO_DURATION_SECONDS")
+    if not max_video_duration:
+        max_video_duration = _DEFAULT_MAX_VIDEO_DURATION_SECONDS
+
+    raw_cooldown = _int_from_env("ADDRADIO_COOLDOWN_SECONDS")
+    if raw_cooldown is None:
+        cooldown_seconds = _DEFAULT_COOLDOWN_SECONDS
+    elif raw_cooldown < 0:
+        logging.warning(
+            "ADDRADIO_COOLDOWN_SECONDS=%s is negative; disabling cooldown",
+            raw_cooldown,
+        )
+        cooldown_seconds = 0
+    else:
+        cooldown_seconds = raw_cooldown
+
+    health_host = os.getenv("HEALTH_HOST", "0.0.0.0")
+    health_port = _int_from_env("HEALTH_PORT") or 8081
+
+    return BotConfig(
+        token=token,
+        channel_id=channel_id,
+        guild_id=guild_id,
+        playlist_id=playlist_id,
+        playlist_url=playlist_url,
+        max_video_duration_seconds=max_video_duration,
+        cooldown_seconds=cooldown_seconds,
+        health_host=health_host,
+        health_port=health_port,
+    )
+
+
+__all__ = ["BotConfig", "load_config", "_bool_from_env", "_int_from_env"]

--- a/bot/cooldown.py
+++ b/bot/cooldown.py
@@ -1,0 +1,48 @@
+"""Utilities for tracking per-user cooldowns."""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Dict
+
+
+class CooldownTracker:
+    """Track cooldown windows for users interacting with the bot."""
+
+    def __init__(self, cooldown_seconds: int) -> None:
+        self._cooldown_seconds = max(0, cooldown_seconds)
+        self._timestamps: Dict[int, float] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        """Return ``True`` when cooldown enforcement is active."""
+
+        return self._cooldown_seconds > 0
+
+    async def remaining(self, user_id: int, *, now: float | None = None) -> float:
+        """Return the remaining cooldown for ``user_id`` in seconds."""
+
+        if not self.enabled:
+            return 0.0
+
+        current = time.time() if now is None else now
+        async with self._lock:
+            last = self._timestamps.get(user_id)
+            if last is None:
+                return 0.0
+            remaining = self._cooldown_seconds - (current - last)
+        return remaining if remaining > 0 else 0.0
+
+    async def mark(self, user_id: int, *, now: float | None = None) -> None:
+        """Record the current time for ``user_id``'s cooldown window."""
+
+        if not self.enabled:
+            return
+
+        current = time.time() if now is None else now
+        async with self._lock:
+            self._timestamps[user_id] = current
+
+
+__all__ = ["CooldownTracker"]

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,5 +1,6 @@
-import os, logging, asyncio, time, math
-from typing import Callable, TypeVar, Any
+import logging
+import math
+import time
 
 try:  # pragma: no cover - exercised indirectly via tests when discord missing
     import discord  # type: ignore
@@ -8,12 +9,10 @@ except Exception as exc:  # pragma: no cover - the fallback itself is tested
         "discord import failed (%s); using lightweight stub", exc,
     )
     from . import discord_stub as discord  # type: ignore
-from dotenv import load_dotenv
-from .youtube import (
-    add_to_playlist,
-    video_exists,
-    get_video_metadata,
-)
+from .config import load_config
+from .cooldown import CooldownTracker
+from .retry import call_with_retry
+from .youtube import add_to_playlist, get_video_metadata, video_exists
 from .youtube import CredentialsExpiredError, MissingGoogleDependenciesError
 try:
     # discord.py depends on aiohttp; use it for an in-process health endpoint
@@ -21,68 +20,6 @@ try:
 except Exception:  # pragma: no cover - only if aiohttp missing at runtime
     web = None  # type: ignore
 from .youtube.urls import canonical_video_ids_from_text
-
-_T = TypeVar("_T")
-
-_FAST_RETRY_DELAY_SECONDS = 5
-_FAST_RETRY_ATTEMPTS = 10
-_SLOW_RETRY_DELAYS = (60, 300, 600)
-_RETRY_WAIT_SECONDS: tuple[int, ...] = (
-    (0,)
-    + (_FAST_RETRY_DELAY_SECONDS,) * _FAST_RETRY_ATTEMPTS
-    + _SLOW_RETRY_DELAYS
-)
-_NON_RETRYABLE_EXCEPTIONS = (
-    CredentialsExpiredError,
-    MissingGoogleDependenciesError,
-)
-
-
-async def _call_with_retry(
-    func: Callable[..., _T],
-    *args: Any,
-    description: str | None = None,
-    **kwargs: Any,
-) -> _T:
-    """Execute ``func`` with exponential backoff style retries.
-
-    Performs quick retries every 5 seconds for the first ten failures and then
-    slows down to 1, 5, and 10 minute intervals before giving up.
-    """
-
-    desc = description or getattr(func, "__name__", "operation")
-    total_attempts = len(_RETRY_WAIT_SECONDS)
-    last_exc: BaseException | None = None
-
-    for attempt, wait_seconds in enumerate(_RETRY_WAIT_SECONDS, start=1):
-        if attempt > 1 and wait_seconds:
-            logging.info(
-                "Retrying %s in %s seconds (attempt %s/%s)",
-                desc,
-                wait_seconds,
-                attempt,
-                total_attempts,
-            )
-            await asyncio.sleep(wait_seconds)
-
-        try:
-            return await asyncio.to_thread(func, *args, **kwargs)
-        except _NON_RETRYABLE_EXCEPTIONS:
-            raise
-        except Exception as exc:  # pragma: no cover - exercised via tests
-            last_exc = exc
-            if attempt == total_attempts:
-                break
-            logging.warning(
-                "Attempt %s/%s for %s failed: %s",
-                attempt,
-                total_attempts,
-                desc,
-                exc,
-            )
-
-    assert last_exc is not None  # For mypy; we only exit loop on failure
-    raise last_exc
 
 # Best-effort detection of Discord HTTP errors without tightly coupling to discord.py
 def _is_unknown_interaction_error(exc: Exception) -> bool:
@@ -157,83 +94,26 @@ async def _safe_followup_send(
             return
         raise
 
-load_dotenv()  # grabs .env mounted by compose
-
-
-def _int_from_env(name: str) -> int | None:
-    """Parse an integer environment variable, returning ``None`` if unset or invalid."""
-
-    raw = os.getenv(name)
-    if raw is None:
-        return None
-    try:
-        return int(raw)
-    except (TypeError, ValueError):
-        logging.warning("Environment variable %s=%r is not a valid integer", name, raw)
-        return None
-
-
-def _bool_from_env(name: str, *, default: bool) -> bool:
-    """Return a boolean parsed from the environment, accepting common truthy strings."""
-
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-
-    normalized = raw.strip().lower()
-    if normalized in {"1", "true", "yes", "on"}:
-        return True
-    if normalized in {"0", "false", "no", "off"}:
-        return False
-
-    logging.warning("Environment variable %s=%r is not a recognized boolean", name, raw)
-    return default
-
-
-TOKEN = os.getenv("DISCORD_TOKEN")
-CHANNEL_ID = _int_from_env("CHANNEL_ID")
-GUILD_ID = _int_from_env("GUILD_ID")
-PLAYLIST = os.getenv("PLAYLIST_ID")
-
-
-def _resolve_playlist_url() -> str | None:
-    """Return a shareable playlist URL if available."""
-
-    explicit = os.getenv("PLAYLIST_URL")
-    if explicit:
-        return explicit
-    if PLAYLIST:
-        return f"https://youtube.com/playlist?list={PLAYLIST}"
-    return None
-
 logging.basicConfig(level=logging.INFO)
+CONFIG = load_config()
+
+TOKEN = CONFIG.token
+CHANNEL_ID = CONFIG.channel_id
+GUILD_ID = CONFIG.guild_id
+PLAYLIST = CONFIG.playlist_id
+PLAYLIST_URL = CONFIG.resolved_playlist_url
+
 intents = discord.Intents.default()
 bot = discord.Client(intents=intents)
- 
+
 # Slash commands (discord.app_commands) if available
 app_commands = getattr(discord, "app_commands", None)
 tree = app_commands.CommandTree(bot) if app_commands else None
 
 START_TIME = time.time()
 _health_started = False
-MAX_VIDEO_DURATION_SECONDS = 10 * 60
-_DEFAULT_ADDRADIO_COOLDOWN_SECONDS = 30
-
-_configured_cooldown = _int_from_env("ADDRADIO_COOLDOWN_SECONDS")
-if _configured_cooldown is None:
-    ADDRADIO_COOLDOWN_SECONDS = _DEFAULT_ADDRADIO_COOLDOWN_SECONDS
-elif _configured_cooldown < 0:
-    logging.warning(
-        "ADDRADIO_COOLDOWN_SECONDS=%s is negative; disabling cooldown",
-        _configured_cooldown,
-    )
-    ADDRADIO_COOLDOWN_SECONDS = 0
-else:
-    ADDRADIO_COOLDOWN_SECONDS = _configured_cooldown
-
-_user_cooldowns: dict[int, float] = {}
-_user_cooldown_lock = asyncio.Lock()
-
+MAX_VIDEO_DURATION_SECONDS = CONFIG.max_video_duration_seconds
+_cooldowns = CooldownTracker(CONFIG.cooldown_seconds)
 
 def _format_duration(total_seconds: int) -> str:
     h, rem = divmod(max(0, int(total_seconds)), 3600)
@@ -278,9 +158,8 @@ def _build_announcement_content(content_prefix: str | None, line: str) -> str:
     if content_prefix:
         parts.append(content_prefix)
     parts.append(line)
-    playlist_url = _resolve_playlist_url()
-    if playlist_url:
-        parts.append(f"Listen to the playlist: {playlist_url}")
+    if PLAYLIST_URL:
+        parts.append(f"Listen to the playlist: {PLAYLIST_URL}")
     return "\n".join(parts)
 
 
@@ -343,27 +222,19 @@ async def _resolve_channel_for_interaction(interaction):
 async def _get_cooldown_remaining(user_id: int, *, now: float | None = None) -> float:
     """Return the remaining cooldown in seconds for ``user_id``."""
 
-    if ADDRADIO_COOLDOWN_SECONDS <= 0:
+    if not _cooldowns.enabled:
         return 0.0
 
-    current = time.time() if now is None else now
-    async with _user_cooldown_lock:
-        last = _user_cooldowns.get(user_id)
-        if last is None:
-            return 0.0
-        remaining = ADDRADIO_COOLDOWN_SECONDS - (current - last)
-    return remaining if remaining > 0 else 0.0
+    return await _cooldowns.remaining(user_id, now=now)
 
 
 async def _mark_cooldown(user_id: int, *, now: float | None = None) -> None:
     """Record the current timestamp for ``user_id``'s cooldown."""
 
-    if ADDRADIO_COOLDOWN_SECONDS <= 0:
+    if not _cooldowns.enabled:
         return
 
-    current = time.time() if now is None else now
-    async with _user_cooldown_lock:
-        _user_cooldowns[user_id] = current
+    await _cooldowns.mark(user_id, now=now)
 
 
 async def _start_health_server() -> None:
@@ -388,8 +259,8 @@ async def _start_health_server() -> None:
 
     app.add_routes([web.get("/healthz", health), web.get("/", health)])
 
-    host = os.getenv("HEALTH_HOST", "0.0.0.0")
-    port = int(os.getenv("HEALTH_PORT", "8081"))
+    host = CONFIG.health_host
+    port = CONFIG.health_port
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, host=host, port=port)
@@ -409,7 +280,7 @@ async def on_ready():
         except Exception:
             logging.exception("Failed to start health server")
 
-    health_port = os.getenv("HEALTH_PORT", "8081")
+    health_port = CONFIG.health_port
     logging.info("READY playlist=%s channel=%s health=http://localhost:%s/healthz",
                  PLAYLIST, CHANNEL_ID, health_port)
 
@@ -490,7 +361,7 @@ if tree is not None:
 
             for vid in vids:
                 try:
-                    if await _call_with_retry(
+                    if await call_with_retry(
                         video_exists,
                         vid,
                         PLAYLIST,
@@ -499,7 +370,7 @@ if tree is not None:
                         duplicates.append(vid)
                         continue
 
-                    meta = await _call_with_retry(
+                    meta = await call_with_retry(
                         get_video_metadata,
                         vid,
                         description=f"fetch metadata for {vid}",
@@ -510,7 +381,7 @@ if tree is not None:
                         too_long.append((vid, title))
                         continue
 
-                    await _call_with_retry(
+                    await call_with_retry(
                         add_to_playlist,
                         vid,
                         PLAYLIST,

--- a/bot/retry.py
+++ b/bot/retry.py
@@ -1,0 +1,67 @@
+"""Retry helpers for functions that interact with remote services."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, TypeVar
+
+from .youtube import CredentialsExpiredError, MissingGoogleDependenciesError
+
+_T = TypeVar("_T")
+
+_FAST_RETRY_DELAY_SECONDS = 5
+_FAST_RETRY_ATTEMPTS = 10
+_SLOW_RETRY_DELAYS = (60, 300, 600)
+RETRY_WAIT_SECONDS: tuple[int, ...] = (
+    (0,) + (_FAST_RETRY_DELAY_SECONDS,) * _FAST_RETRY_ATTEMPTS + _SLOW_RETRY_DELAYS
+)
+_NON_RETRYABLE_EXCEPTIONS = (
+    CredentialsExpiredError,
+    MissingGoogleDependenciesError,
+)
+
+
+async def call_with_retry(
+    func: Callable[..., _T],
+    *args: Any,
+    description: str | None = None,
+    **kwargs: Any,
+) -> _T:
+    """Execute ``func`` with retries and return its eventual result."""
+
+    desc = description or getattr(func, "__name__", "operation")
+    total_attempts = len(RETRY_WAIT_SECONDS)
+    last_exc: BaseException | None = None
+
+    for attempt, wait_seconds in enumerate(RETRY_WAIT_SECONDS, start=1):
+        if attempt > 1 and wait_seconds:
+            logging.info(
+                "Retrying %s in %s seconds (attempt %s/%s)",
+                desc,
+                wait_seconds,
+                attempt,
+                total_attempts,
+            )
+            await asyncio.sleep(wait_seconds)
+
+        try:
+            return await asyncio.to_thread(func, *args, **kwargs)
+        except _NON_RETRYABLE_EXCEPTIONS:
+            raise
+        except Exception as exc:  # pragma: no cover - exercised via tests
+            last_exc = exc
+            if attempt == total_attempts:
+                break
+            logging.warning(
+                "Attempt %s/%s for %s failed: %s",
+                attempt,
+                total_attempts,
+                desc,
+                exc,
+            )
+
+    assert last_exc is not None  # We only exit loop on failure
+    raise last_exc
+
+
+__all__ = ["call_with_retry", "RETRY_WAIT_SECONDS"]

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -1,26 +1,23 @@
-def test_bool_from_env_truthy(monkeypatch):
-    import bot.main as main
+from bot.config import _bool_from_env
 
+
+def test_bool_from_env_truthy(monkeypatch):
     monkeypatch.setenv("FEATURE_FLAG", "true")
 
-    assert main._bool_from_env("FEATURE_FLAG", default=False) is True
+    assert _bool_from_env("FEATURE_FLAG", default=False) is True
 
 
 def test_bool_from_env_falsey(monkeypatch):
-    import bot.main as main
-
     monkeypatch.setenv("FEATURE_FLAG", "OFF")
 
-    assert main._bool_from_env("FEATURE_FLAG", default=True) is False
+    assert _bool_from_env("FEATURE_FLAG", default=True) is False
 
 
 def test_bool_from_env_invalid_logs_warning(monkeypatch, caplog):
-    import bot.main as main
-
     monkeypatch.setenv("FEATURE_FLAG", "maybe")
 
     with caplog.at_level("WARNING"):
-        result = main._bool_from_env("FEATURE_FLAG", default=True)
+        result = _bool_from_env("FEATURE_FLAG", default=True)
 
     assert result is True
     assert any("not a recognized boolean" in message for message in caplog.messages)


### PR DESCRIPTION
## Summary
- extract configuration parsing into a dedicated `bot.config` module and reuse it from the bot entry point
- add reusable cooldown and retry helpers to simplify `bot.main`
- update existing tests to exercise the new helpers directly

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_69014e08d300832c95c08c97e625169c